### PR TITLE
Añadir flujo de trabajo para parchar imagen de recuperación

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,0 +1,26 @@
+name: Patch Recovery Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  patch_image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download recovery image
+        run: |
+          curl -L https://we.tl/t-MKbgvT5uQT -o recovery.img
+
+      - name: Patch the image
+        run: |
+          # Aquí debes agregar el comando o herramienta que usas para parchar la imagen
+          echo "Patching recovery image..."
+          # Por ejemplo, si tienes un script o herramienta, llama a ese script:
+          # ./patch_tool recovery.img patched_recovery.img
+
+      - name: Upload patched image
+        uses: actions/upload-artifact@v2
+        with:
+          name: patched-recovery.img
+          path: ./patched-recovery.img
+          


### PR DESCRIPTION
Este flujo de trabajo permite parchear una imagen de recuperación mediante GitHub Actions. Incluye pasos para descargar, parchar y subir la imagen parcheada como artefacto.